### PR TITLE
Making the library use an actual middleware instead of using appb…

### DIFF
--- a/KnowYourLimits.AspNetCore/IpClientIdentityProvider.cs
+++ b/KnowYourLimits.AspNetCore/IpClientIdentityProvider.cs
@@ -6,11 +6,6 @@ using Microsoft.AspNetCore.Http.Features;
 
 namespace KnowYourLimits.AspNetCore
 {
-    public interface IProvider
-    {
-        HttpContext Context { get; set; }
-    }
-
     public class IpClientIdentityProvider<TClientIdentity> : IHttpContextIdentityProvider<TClientIdentity>
         where TClientIdentity : IClientIdentity, new()
     {
@@ -23,12 +18,16 @@ namespace KnowYourLimits.AspNetCore
             if(Context == null) throw new ArgumentException(nameof(Context));
 
             var httpConnectionFeature = Context.Features.Get<IHttpConnectionFeature>();
-            var userHostAddress = httpConnectionFeature?.RemoteIpAddress.ToString();
+            var userHostAddress = httpConnectionFeature?.RemoteIpAddress.ToString() ?? "";
 
             if (_clientIdentities.ContainsKey(userHostAddress)) return _clientIdentities[userHostAddress];
 
             var newIdentity = new TClientIdentity {UniqueIdentifier = userHostAddress};
-            _clientIdentities.TryAdd(userHostAddress, newIdentity);
+
+            if (!string.IsNullOrWhiteSpace(userHostAddress))
+            {
+                _clientIdentities.TryAdd(userHostAddress, newIdentity);
+            }
 
             return newIdentity;
         }

--- a/KnowYourLimits.AspNetCore/KnowYourLimits.AspNetCore.csproj
+++ b/KnowYourLimits.AspNetCore/KnowYourLimits.AspNetCore.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Elliot Coyle</Authors>
     <Company />
@@ -13,10 +13,12 @@
     <FileVersion>2.2.0.0</FileVersion>
     <AssemblyVersion>2.2.0.0</AssemblyVersion>
     <Version>2.3.2</Version>
+    <PackageVersion>3.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="SecurityCodeScan" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KnowYourLimits.AspNetCore/RateLimiterMiddlewareExtensions.cs
+++ b/KnowYourLimits.AspNetCore/RateLimiterMiddlewareExtensions.cs
@@ -1,0 +1,23 @@
+﻿using KnowYourLimits.Identity;
+using KnowYourLimits.Strategies;
+using Microsoft.AspNetCore.Builder;
+
+namespace KnowYourLimits.AspNetCore
+{
+    // ReSharper disable once UnusedMember.Global
+    public static class RateLimiterMiddlewareExtensions
+    {
+        // ReSharper disable once UnusedMember.Global
+        public static void UseRateLimiting<TClientIdentity>(this IApplicationBuilder applicationBuilder,
+            IRateLimitStrategy<TClientIdentity> rateLimitStrategy)
+            where TClientIdentity : IClientIdentity, new()
+        {
+            if (rateLimitStrategy.IdentityProvider == null)
+            {
+                rateLimitStrategy.IdentityProvider = new IpClientIdentityProvider<TClientIdentity>();
+            }
+
+            applicationBuilder.UseMiddleware<RateLimiterMiddleware<TClientIdentity>>(rateLimitStrategy);
+        }
+    }
+}

--- a/KnowYourLimits.UnitTests/Identity/PredictableClientIdentityProvider.cs
+++ b/KnowYourLimits.UnitTests/Identity/PredictableClientIdentityProvider.cs
@@ -2,10 +2,10 @@
 
 namespace KnowYourLimits.UnitTests.Identity
 {
-    public class PredictableClientIdentityProvider<TClientIdentity> : IClientIdentityProvider<TClientIdentity> 
+    public class PredictableClientIdentityProvider<TClientIdentity> : IClientIdentityProvider<TClientIdentity>
         where TClientIdentity : IClientIdentity
     {
-        public TClientIdentity IdentityToReturn { get; set; }
+        private TClientIdentity IdentityToReturn { get; set; }
 
         public PredictableClientIdentityProvider(TClientIdentity identityToReturn)
         {

--- a/KnowYourLimits.UnitTests/KnowYourLimits.UnitTests.csproj
+++ b/KnowYourLimits.UnitTests/KnowYourLimits.UnitTests.csproj
@@ -1,8 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -10,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="SecurityCodeScan" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KnowYourLimits.UnitTests/LeakyBucketRateLimitStrategyTests.cs
+++ b/KnowYourLimits.UnitTests/LeakyBucketRateLimitStrategyTests.cs
@@ -104,10 +104,10 @@ namespace KnowYourLimits.UnitTests
             var rateLimiter = new LeakyBucketRateLimitStrategy(config);
 
             rateLimiter.ReduceAllowanceBy(5);
-            Assert.Equal(false, rateLimiter.HasRemainingAllowance());
+            Assert.False(rateLimiter.HasRemainingAllowance());
 
             Thread.Sleep(TimeSpan.FromSeconds(6));
-            Assert.Equal(true, rateLimiter.HasRemainingAllowance());
+            Assert.True(rateLimiter.HasRemainingAllowance());
         }
 
         [Fact]
@@ -130,22 +130,22 @@ namespace KnowYourLimits.UnitTests
             var rateLimiter = new LeakyBucketRateLimitStrategy(config);
 
             rateLimiter.ReduceAllowanceBy(3);
-            Assert.Equal(true, rateLimiter.HasRemainingAllowance());
+            Assert.True(rateLimiter.HasRemainingAllowance());
             Assert.Equal(37, rateLimiter.GetRemainingAllowance());
             Thread.Sleep(TimeSpan.FromSeconds(1));
 
             rateLimiter.ReduceAllowanceBy(3);
-            Assert.Equal(true, rateLimiter.HasRemainingAllowance());
+            Assert.True(rateLimiter.HasRemainingAllowance());
             Assert.Equal(36, rateLimiter.GetRemainingAllowance());
             Thread.Sleep(TimeSpan.FromSeconds(1));
 
             rateLimiter.ReduceAllowanceBy(3);
-            Assert.Equal(true, rateLimiter.HasRemainingAllowance());
+            Assert.True(rateLimiter.HasRemainingAllowance());
             Assert.Equal(35, rateLimiter.GetRemainingAllowance());
             Thread.Sleep(TimeSpan.FromSeconds(1));
 
             rateLimiter.ReduceAllowanceBy(3);
-            Assert.Equal(true, rateLimiter.HasRemainingAllowance());
+            Assert.True(rateLimiter.HasRemainingAllowance());
             Assert.Equal(34, rateLimiter.GetRemainingAllowance());
             Thread.Sleep(TimeSpan.FromSeconds(1));
         }
@@ -171,8 +171,10 @@ namespace KnowYourLimits.UnitTests
             var successfulRequests = 0;
             var failedRequests = 0;
 
+#pragma warning disable 1998
             async Task OnSuccessfulRequest() => successfulRequests++;
             async Task OnFailedRequest() => failedRequests++;
+#pragma warning restore 1998
 
             await rateLimiter.OnRequest(OnSuccessfulRequest, OnFailedRequest);
             Assert.Equal(1, successfulRequests);
@@ -213,11 +215,10 @@ namespace KnowYourLimits.UnitTests
 
             var rateLimiter = new LeakyBucketRateLimitStrategy(config);
 
-            var successfulRequests = 0;
-            var failedRequests = 0;
-
-            async Task OnSuccessfulRequest() => successfulRequests++;
-            async Task OnFailedRequest() => failedRequests++;
+#pragma warning disable 1998
+            async Task OnSuccessfulRequest() { }
+            async Task OnFailedRequest() { }
+#pragma warning restore 1998
 
             for (var i = 0; i < requestCount; i++)
             {

--- a/KnowYourLimits/KnowYourLimits.csproj
+++ b/KnowYourLimits/KnowYourLimits.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Elliot Coyle</Authors>
     <Company />
@@ -13,6 +13,11 @@
     <AssemblyVersion>2.0.1.0</AssemblyVersion>
     <FileVersion>2.0.1.0</FileVersion>
     <Version>2.1.0</Version>
+    <PackageVersion>3.0.0</PackageVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="SecurityCodeScan" Version="3.3.0" />
+  </ItemGroup>
+  
 </Project>

--- a/KnowYourLimits/Strategies/LeakyBucket/LeakyBucketClientIdentity.cs
+++ b/KnowYourLimits/Strategies/LeakyBucket/LeakyBucketClientIdentity.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using KnowYourLimits.Identity;
 
 namespace KnowYourLimits.Strategies.LeakyBucket
 {
     public class LeakyBucketClientIdentity : IClientIdentity
     {
-        public bool Equals(IClientIdentity other) => other.UniqueIdentifier == UniqueIdentifier;
+        public bool Equals(IClientIdentity other) => other?.UniqueIdentifier == UniqueIdentifier;
         public string UniqueIdentifier { get; set; }
         public long RequestCount { get; set; }
         public DateTime? LastLeak { get; set; }

--- a/KnowYourLimits/Strategies/LeakyBucket/LeakyBucketConfiguration.cs
+++ b/KnowYourLimits/Strategies/LeakyBucket/LeakyBucketConfiguration.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using KnowYourLimits.Identity;
 
 namespace KnowYourLimits.Strategies.LeakyBucket


### PR DESCRIPTION
…er.apply

- Bumped package version to 3.0.0
- netcoreapp3.0 added to target frameworks
- Added SecurityCodeScan to help prevent any security flaws
- Fixing a bunch of spacing errors
- Fixing a bunch of build warnings
- Updated some of the XML comments
- Now using a middleware instead of appBuilder.apply

Issue #14 